### PR TITLE
Replace internal pip function call with subprocess

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.3"
+  - "3.6"
   - "2.7"
 install: pip install -r requirements.txt
 before_script: pep8 .

--- a/pip_prometheus/__init__.py
+++ b/pip_prometheus/__init__.py
@@ -1,6 +1,7 @@
-import pip
 import prometheus_client
 import sys
+import subprocess
+import json
 
 
 def LoadInstallations(counter):
@@ -10,9 +11,12 @@ def LoadInstallations(counter):
     be increased each time. Since Prometheus counters are never
     decreased, the aggregated results will not make sense.
     """
-    installations = pip.utils.get_installed_distributions()
+    process = subprocess.Popen(["pip", "list", "--format=json"],
+                               stdout=subprocess.PIPE)
+    output, _ = process.communicate()
+    installations = json.loads(output)
     for i in installations:
-        counter.labels(i.key, i.version).inc()
+        counter.labels(i["name"], i["version"]).inc()
 
 
 _installed_apps = prometheus_client.Counter(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 prometheus-client>=0.0.8
-pip>=6.0.0
+pip>=9.0.0
 pep8>=1.6.2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     install_requires=[
         "prometheus_client>=0.0.8",
-        "pip>=6.0.0",
+        "pip>=9.0.0",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -6,7 +6,7 @@ import pip_prometheus
 
 class TestPipPrometheus(unittest.TestCase):
     def test_exportsPython(self):
-        self.assertEquals(
+        self.assertEqual(
             1, REGISTRY.get_sample_value(
                 'pip_system_components_map',
                 labels={


### PR DESCRIPTION
I discovered this a while back - it looks like this library no longer is functioning on pip 10:

```
root@4ac276bd9caa:/django-prometheus# pip --version
pip 10.0.1 from /usr/local/lib/python3.6/site-packages/pip (python 3.6)
root@4ac276bd9caa:/django-prometheus# python setup.py test
running test
running egg_info
creating django_prometheus.egg-info
writing django_prometheus.egg-info/PKG-INFO
writing dependency_links to django_prometheus.egg-info/dependency_links.txt
writing requirements to django_prometheus.egg-info/requires.txt
writing top-level names to django_prometheus.egg-info/top_level.txt
writing manifest file 'django_prometheus.egg-info/SOURCES.txt'
reading manifest file 'django_prometheus.egg-info/SOURCES.txt'
writing manifest file 'django_prometheus.egg-info/SOURCES.txt'
running build_ext
Traceback (most recent call last):
  File "setup.py", line 42, in <module>
    "License :: OSI Approved :: Apache Software License",
  File "/usr/local/lib/python3.6/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/local/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/local/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.6/site-packages/setuptools/command/test.py", line 226, in run
    self.run_tests()
  File "/usr/local/lib/python3.6/site-packages/setuptools/command/test.py", line 248, in run_tests
    exit=False,
  File "/usr/local/lib/python3.6/unittest/main.py", line 94, in __init__
    self.parseArgs(argv)
  File "/usr/local/lib/python3.6/unittest/main.py", line 141, in parseArgs
    self.createTests()
  File "/usr/local/lib/python3.6/unittest/main.py", line 148, in createTests
    self.module)
  File "/usr/local/lib/python3.6/unittest/loader.py", line 219, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/local/lib/python3.6/unittest/loader.py", line 219, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/local/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/django-prometheus/django_prometheus/__init__.py", line 14, in <module>
    import pip_prometheus
  File "/usr/local/lib/python3.6/site-packages/pip_prometheus/__init__.py", line 25, in <module>
    LoadInstallations(_installed_apps)
  File "/usr/local/lib/python3.6/site-packages/pip_prometheus/__init__.py", line 13, in LoadInstallations
    installations = pip.utils.get_installed_distributions()
AttributeError: module 'pip' has no attribute 'utils'
```

This resolves that issue.