### PR TITLE
Fix issue w/ python 3, add support for newer versions of python.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+dist: xenial
 language: python
 python:
+  - "3.5"
   - "3.6"
+  - "3.7"
   - "2.7"
 install: pip install -r requirements.txt
 before_script: pep8 .

--- a/pip_prometheus/__init__.py
+++ b/pip_prometheus/__init__.py
@@ -14,7 +14,7 @@ def LoadInstallations(counter):
     process = subprocess.Popen(["pip", "list", "--format=json"],
                                stdout=subprocess.PIPE)
     output, _ = process.communicate()
-    installations = json.loads(output)
+    installations = json.loads(output.decode())
     for i in installations:
         counter.labels(i["name"], i["version"]).inc()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prometheus-client>=0.0.8
+prometheus-client>=0.7.0
 pip>=9.0.0
 pep8>=1.6.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ instructions.
 
 setup(
     name="pip-prometheus",
-    version="1.1.0",
+    version="1.2.0",
     author="Uriel Corfa",
     author_email="uriel@corfa.fr",
     description=(
@@ -23,7 +23,7 @@ setup(
     test_suite="tests",
     long_description=LONG_DESCRIPTION,
     install_requires=[
-        "prometheus_client>=0.0.8",
+        "prometheus_client>=0.7.0",
         "pip>=9.0.0",
     ],
     classifiers=[
@@ -33,5 +33,11 @@ setup(
         "Intended Audience :: System Administrators",
         "Topic :: System :: Monitoring",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -8,7 +8,7 @@ class TestPipPrometheus(unittest.TestCase):
     def test_exportsPython(self):
         self.assertEqual(
             1, REGISTRY.get_sample_value(
-                'pip_system_components_map',
+                'pip_system_components_map_total',
                 labels={
                     'component': 'python',
                     'version': sys.version,


### PR DESCRIPTION
```

Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    "License :: OSI Approved :: Apache Software License",
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/__init__.py", line 143, in setup
    return distutils.core.setup(**attrs)
  File "/opt/python/3.5.6/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/opt/python/3.5.6/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/opt/python/3.5.6/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/command/test.py", line 228, in run
    self.run_tests()
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/command/test.py", line 250, in run_tests
    exit=False,
  File "/opt/python/3.5.6/lib/python3.5/unittest/main.py", line 94, in __init__
    self.parseArgs(argv)
  File "/opt/python/3.5.6/lib/python3.5/unittest/main.py", line 141, in parseArgs
    self.createTests()
  File "/opt/python/3.5.6/lib/python3.5/unittest/main.py", line 148, in createTests
    self.module)
  File "/opt/python/3.5.6/lib/python3.5/unittest/loader.py", line 219, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/opt/python/3.5.6/lib/python3.5/unittest/loader.py", line 219, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/opt/python/3.5.6/lib/python3.5/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/travis/build/korfuri/django-prometheus/django_prometheus/__init__.py", line 15, in <module>
    import pip_prometheus
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/pip_prometheus/__init__.py", line 29, in <module>
    LoadInstallations(_installed_apps)
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/pip_prometheus/__init__.py", line 17, in LoadInstallations
    installations = json.loads(output)
  File "/opt/python/3.5.6/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```


https://travis-ci.org/korfuri/django-prometheus/jobs/545338320