### PR TITLE
bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ instructions.
 
 setup(
     name="pip-prometheus",
-    version="1.2.0",
+    version="1.2.1",
     author="Uriel Corfa",
     author_email="uriel@corfa.fr",
     description=(


### PR DESCRIPTION
@korfuri seems that the version 1.2.0 published to pip only has [eggs for python 3.6](https://pypi.org/project/pip-prometheus/1.2.0/#files) and is missing the source, which [previous versions have](https://pypi.org/project/pip-prometheus/1.1.0/#files) meaning this cannot be installed on all supported python versions..
I created this PR so you can merge the version bump and push a new version to pypi that corrects this issue.